### PR TITLE
ElasticSearch Provider Implementation

### DIFF
--- a/Provider/Contracts/IBaseEntity.cs
+++ b/Provider/Contracts/IBaseEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace Provider.Contracts;
+
+public interface IBaseEntity
+{
+    Guid Id { get; init; }
+    DateTimeOffset CreateOn { get; init; }
+    DateTimeOffset? UpdateOn { get; init; }
+    Guid Version { get; init; }
+}
+

--- a/Provider/Contracts/IBaseRepository.cs
+++ b/Provider/Contracts/IBaseRepository.cs
@@ -1,0 +1,26 @@
+﻿using Provider.Results;
+
+namespace Provider.Contracts;
+
+public interface IBaseRepository
+{
+    Task<long> CountAsync();
+}
+
+public interface IBaseRepository<T> : IBaseRepository where T : IBaseEntity
+{
+    Task<CanDeleteResult> CanDelete(T entity, CancellationToken cancellationToken);
+    Task<DeletedResult> DeleteAsync(T entity, CancellationToken cancellationToken);
+    Task<InsertResult<T>> InsertAsync(T entity, CancellationToken cancellationToken);
+    Task<List<InsertResult<T>>> InsertAllAsync(List<T> entities, CancellationToken cancellationToken);
+    Task<UpdatedResult<T>> UpdateAsync(T entity, CancellationToken cancellationToken);
+    Task<List<UpdatedResult<T>>> UpdateAllAsync(List<T> entities, CancellationToken cancellationToken);
+    Task<IncrementResult> IncrementAsync(Guid id, string field, Guid version, double amount = 1);
+    Task<T?> FirstOrDefaultAsync(CancellationToken cancellationToken);
+    Task<T?> SingleOrDefaultAsync(Guid id, CancellationToken cancellationToken);
+    Task<T> SingleAsync(Guid id, CancellationToken cancellationToken);
+    Task<List<T>> ListAsync(CancellationToken cancellationToken);
+    Task<List<T>> ListAsync(List<Guid?> ids, CancellationToken cancellationToken);
+    Task<List<T>> ListAsync(List<Guid> ids, CancellationToken cancellationToken);
+    Task<IPagedData<T>> ListPagedAsync(IPagedRequest request, CancellationToken cancellationToken);
+}

--- a/Provider/Contracts/IPagedData.cs
+++ b/Provider/Contracts/IPagedData.cs
@@ -1,0 +1,8 @@
+﻿namespace Provider.Contracts;
+
+public interface IPagedData<T>
+{
+    List<T> Result { get; set; }
+
+    long TotalCount { get; set; }
+}

--- a/Provider/Contracts/IPagedRequest.cs
+++ b/Provider/Contracts/IPagedRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Provider.Contracts;
+
+public interface IPagedRequest
+{
+    int Page { get; set; }
+    int PageSize { get; set; }
+    string? Sort { get; set; }
+}

--- a/Provider/Extensions/ServiceCollectionExtensions.cs
+++ b/Provider/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Nest;
+using Provider.Configuration;
+
+
+namespace Provider.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection ConfigureElasticSearch(this IServiceCollection services, ElasticConfiguration elasticConfiguration)
+    {
+        var uri = new Uri(elasticConfiguration.Uri);
+        services.AddSingleton<IElasticClient>(
+            new ElasticClient(
+                new ConnectionSettings(uri)
+                    .BasicAuthentication(elasticConfiguration.Username, elasticConfiguration.Password)
+            ));
+
+        return services;
+    }
+}

--- a/Provider/Extensions/ToResultModel.cs
+++ b/Provider/Extensions/ToResultModel.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Localization;
+using Nest;
+using Provider.Results;
+
+namespace Provider.Extensions;
+
+public static class ToResultModel
+{
+
+    #region Insert
+    public static InsertResult<T> ToInsertResult<T>(this IndexResponse response, T entity, IStringLocalizer localizer)
+    {
+        var message = response.Result == Result.Created ? localizer["EntityInserted"] : localizer["EntityNotInserted"];
+        return new InsertResult<T>(entity, response.IsValid ? 1 : 0, message);
+    }
+
+    public static InsertResult<T> ToInsertResult<T>(this T entity, bool inserted, IStringLocalizer localizer)
+    {
+        var message = inserted ? localizer["EntityInserted"] : localizer["EntityNotInserted"];
+        return new InsertResult<T>(entity, inserted ? 1 : 0, message);
+    }
+    #endregion
+
+    #region Update
+    public static UpdatedResult<T> ToUpdateResult<T>(this T entity, Result result, IStringLocalizer localizer)
+    {
+        var updated = result == Result.Updated;
+        var message = updated ? localizer["EntityUpdated"] : localizer["EntityNotUpdated"];
+        return new UpdatedResult<T>(entity, updated ? 1 : 0, message);
+    }
+    public static UpdatedResult<T> ToUpdateResult<T>(this T entity, bool updated, IStringLocalizer localizer)
+    {
+        var message = updated ? localizer["EntityUpdated"] : localizer["EntityNotUpdated"];
+        return new UpdatedResult<T>(entity, updated ? 1 : 0, message);
+    }
+    #endregion
+
+}

--- a/Provider/Provider.csproj
+++ b/Provider/Provider.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="NEST" Version="7.17.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Types\Repositories\" />
+  </ItemGroup>
+
 </Project>

--- a/Provider/Provider.csproj
+++ b/Provider/Provider.csproj
@@ -8,11 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.8" />
     <PackageReference Include="NEST" Version="7.17.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Types\Repositories\" />
   </ItemGroup>
 
 </Project>

--- a/Provider/Provider.csproj
+++ b/Provider/Provider.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="NEST" Version="7.17.5" />
+  </ItemGroup>
+
 </Project>

--- a/Provider/Results/CanDeleteResult.cs
+++ b/Provider/Results/CanDeleteResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Provider.Results;
+
+public record CanDeleteResult(bool CanDelete, string Message = "");

--- a/Provider/Results/DeletedResult.cs
+++ b/Provider/Results/DeletedResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Provider.Results;
+
+public record DeletedResult(CanDeleteResult CanDeleteResult, long DeletedCount = 0) : CanDeleteResult(CanDeleteResult.CanDelete, CanDeleteResult.Message);

--- a/Provider/Results/IncrementResult.cs
+++ b/Provider/Results/IncrementResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Provider.Results;
+
+public record IncrementResult(bool isDone);

--- a/Provider/Results/InsertResult.cs
+++ b/Provider/Results/InsertResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Provider.Results;
+
+public record InsertResult<T>(T entity, long InsertedCount, string message);

--- a/Provider/Results/PagedData.cs
+++ b/Provider/Results/PagedData.cs
@@ -1,0 +1,12 @@
+﻿using Provider.Contracts;
+
+public class PagedData<T> : IPagedData<T>
+{
+    public PagedData(List<T> result, long totalCount)
+    {
+        Result = result;
+        TotalCount = totalCount;
+    }
+    public List<T> Result { get; set; }
+    public long TotalCount { get; set; }
+}

--- a/Provider/Results/UpdatedResult.cs
+++ b/Provider/Results/UpdatedResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Provider.Results;
+
+public record UpdatedResult<T>(T entity, long updatedCount, string message);

--- a/Provider/Types/Entities/BaseElasticEntity.cs
+++ b/Provider/Types/Entities/BaseElasticEntity.cs
@@ -1,0 +1,8 @@
+﻿using Provider.Contracts;
+
+namespace Provider.Types.Entities;
+
+public record BaseElasticEntity(Guid Id, DateTimeOffset CreateOn, DateTimeOffset? UpdateOn, Guid Version) : IBaseEntity
+{
+    protected BaseElasticEntity() : this(Guid.NewGuid(), DateTimeOffset.Now, null, Guid.NewGuid()) { }
+}

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -193,8 +193,10 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return new PagedData<T>(response.Documents.ToList(), response.Total);
     }
 
-    public Task<long> CountAsync()
+    public async Task<long> CountAsync()
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.CountAsync<T>(c => c.Index(GetIndexName()));
+
+        return response.Count;
     }
 }

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -152,9 +152,10 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return response.Source;
     }
 
-    public Task<List<T>> ListAsync(CancellationToken cancellationToken)
+    public async Task<List<T>> ListAsync(CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.SearchAsync<T>(u => u.Index(GetIndexName()).Query(q => q.MatchAll()), cancellationToken);
+        return response.Documents.ToList();
     }
 
     public Task<List<T>> ListAsync(List<Guid?> ids, CancellationToken cancellationToken)

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -171,9 +171,12 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return response.Documents.ToList();
     }
 
-    public Task<List<T>> ListAsync(List<Guid> ids, CancellationToken cancellationToken)
+    public async Task<List<T>> ListAsync(List<Guid> ids, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.SearchAsync<T>(u =>
+            u.Index(GetIndexName()).Query(q =>
+                q.Terms(t => t.Field(f => f.Id).Terms(ids))), cancellationToken);
+        return response.Documents.ToList();
     }
 
     public Task<IPagedData<T>> ListPagedAsync(IPagedRequest request, CancellationToken cancellationToken)

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -132,9 +132,10 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return new IncrementResult(response.IsValid);
     }
 
-    public Task<T?> FirstOrDefaultAsync(CancellationToken cancellationToken)
+    public async Task<T?> FirstOrDefaultAsync(CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.SearchAsync<T>(u => u.Index(GetIndexName()).Query(q => q.MatchAll()).Size(1).TrackTotalHits(false), cancellationToken);
+        return response.Documents.FirstOrDefault();
     }
 
     public Task<T?> SingleOrDefaultAsync(Guid id, CancellationToken cancellationToken)

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.Localization;
+﻿using Elasticsearch.Net;
+using Microsoft.Extensions.Localization;
 using Nest;
 using Provider.Contracts;
+using Provider.Extensions;
 using Provider.Results;
 using Provider.Types.Entities;
 
@@ -46,9 +48,10 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return new DeletedResult(can, response.IsValid ? 1 : 0);
     }
 
-    public Task<InsertResult<T>> InsertAsync(T entity, CancellationToken cancellationToken)
+    public virtual async Task<InsertResult<T>> InsertAsync(T entity, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.IndexAsync(entity, x => x.Index(GetIndexName()).Refresh(Refresh.WaitFor), cancellationToken).ConfigureAwait(false);
+        return response.ToInsertResult(entity, _localizer);
     }
 
     public Task<List<InsertResult<T>>> InsertAllAsync(List<T> entities, CancellationToken cancellationToken)

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -138,9 +138,11 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return response.Documents.FirstOrDefault();
     }
 
-    public Task<T?> SingleOrDefaultAsync(Guid id, CancellationToken cancellationToken)
+    public async Task<T?> SingleOrDefaultAsync(Guid id, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.GetAsync(new DocumentPath<T>(
+            new Id(id)), x => x.Index(GetIndexName()), cancellationToken);
+        return response?.Source;
     }
 
     public Task<T> SingleAsync(Guid id, CancellationToken cancellationToken)

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -145,9 +145,11 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return response?.Source;
     }
 
-    public Task<T> SingleAsync(Guid id, CancellationToken cancellationToken)
+    public async Task<T> SingleAsync(Guid id, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var response = await ElasticClient.GetAsync<T>(id, g => g.Index(GetIndexName()), cancellationToken);
+
+        return response.Source;
     }
 
     public Task<List<T>> ListAsync(CancellationToken cancellationToken)

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.Extensions.Localization;
+using Nest;
+using Provider.Contracts;
+using Provider.Results;
+using Provider.Types.Entities;
+
+namespace Provider.Types.Repositories;
+
+public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : BaseElasticEntity
+{
+    protected IElasticClient ElasticClient { get; }
+    private string _indexName;
+    private readonly IStringLocalizer<BaseElasticRepository<T>> _localizer;
+
+    protected BaseElasticRepository(IElasticClient elasticClient, IStringLocalizer<BaseElasticRepository<T>> localizer)
+    {
+        ElasticClient = elasticClient;
+        _localizer = localizer;
+        _indexName = typeof(T).ToString().ToLower();
+    }
+
+    public string GetIndexName()
+    {
+        return _indexName;
+    }
+
+    public abstract Task<CanDeleteResult> CanDelete(T entity, CancellationToken cancellationToken);
+
+    public Task<DeletedResult> DeleteAsync(T entity, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<InsertResult<T>> InsertAsync(T entity, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<List<InsertResult<T>>> InsertAllAsync(List<T> entities, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<UpdatedResult<T>> UpdateAsync(T entity, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<List<UpdatedResult<T>>> UpdateAllAsync(List<T> entities, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IncrementResult> IncrementAsync(Guid id, string field, Guid version, double amount = 1)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<T?> FirstOrDefaultAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<T?> SingleOrDefaultAsync(Guid id, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<T> SingleAsync(Guid id, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<List<T>> ListAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<List<T>> ListAsync(List<Guid?> ids, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<List<T>> ListAsync(List<Guid> ids, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IPagedData<T>> ListPagedAsync(IPagedRequest request, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<long> CountAsync()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Provider/Types/Repositories/BaseElasticRepository.cs
+++ b/Provider/Types/Repositories/BaseElasticRepository.cs
@@ -179,9 +179,18 @@ public abstract class BaseElasticRepository<T> : IBaseRepository<T> where T : Ba
         return response.Documents.ToList();
     }
 
-    public Task<IPagedData<T>> ListPagedAsync(IPagedRequest request, CancellationToken cancellationToken)
+    public async Task<IPagedData<T>> ListPagedAsync(IPagedRequest request, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var from = (request.Page - 1) * request.PageSize;
+        var size = request.PageSize;
+
+        var response = await ElasticClient.SearchAsync<T>(u => u
+             .Index(GetIndexName())
+             .From(from)
+             .Size(size)
+             .Query(q => q.MatchAll()), cancellationToken);
+
+        return new PagedData<T>(response.Documents.ToList(), response.Total);
     }
 
     public Task<long> CountAsync()


### PR DESCRIPTION
Pull Request Description:
This pull request includes the implementation of an ElasticSearch provider, which allows interacting with an ElasticSearch index. The provider consists of several classes, interfaces, and extension methods that enable various operations such as inserting, updating, deleting, and querying documents in the index.

The following changes have been made:

Added ElasticConfiguration class for configuring the ElasticSearch connection.
Defined interfaces for base entity (IBaseEntity), paged data (IPagedData<T>), and paged request (IPagedRequest).
Introduced record types for result representations such as deletion (CanDeleteResult, DeletedResult), incrementation (IncrementResult), and insertion (InsertResult<T>).
Implemented the PagedData<T> class to represent paginated data.
Created a service collection extension method (ConfigureElasticSearch) for configuring the ElasticSearch client in the service container.
Defined BaseElasticEntity as an abstract base class for ElasticSearch entities.
Implemented the BaseElasticRepository<T> class, which serves as a base repository for ElasticSearch operations.
Added methods for CRUD operations in the repository, including deletion, insertion, updating, incrementing, and retrieval of documents.
Implemented pagination functionality with the ListPagedAsync method in the repository.
Added the CountAsync method for counting the number of documents in the index.
These changes provide a foundation for working with ElasticSearch and enable developers to interact with an ElasticSearch index in a convenient and efficient manner.

Please review and provide any feedback or suggestions for improvement.